### PR TITLE
correctly parse '/' scopes or scopes ending in '/' for scitokens

### DIFF
--- a/src/XrdSciTokens/XrdSciTokensAccess.cc
+++ b/src/XrdSciTokens/XrdSciTokensAccess.cc
@@ -899,7 +899,7 @@ private:
                     if (!strncmp(acl_path, restricted_path.c_str(), acl_path_size)) {
                         // Only do prefix checking on full path components.  If acl_path=/foo and
                         // restricted_path=/foobar, then we shouldn't authorize access to /foobar.
-                        if (restricted_path.size() > acl_path_size && restricted_path[acl_path_size] != '/') {
+                        if (restricted_path.size() > acl_path_size && restricted_path[acl_path_size-1] != '/') {
                             continue;
                         }
                         acl_paths.push_back(restricted_path);


### PR DESCRIPTION
when tokens are given with scope '/' or scope ending in '/', to correctly parse the comparison and restrict it to whichever is the most restrictive subpath between the restricted_path in config and the acl path, the comparison should be with restricted_path[acl_path_size-1], as restricted path is 0-indexed