### PR TITLE
Adding back in removed "CurrentReq.praseLine" call in XrdHttpProcotol…

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -656,6 +656,14 @@ int XrdHttpProtocol::Process(XrdLink *lp) // We ignore the argument here
           TRACE(DEBUG, " Parsing of first line failed with " << result);
           return -1;
         }
+      } else {
+        int result = CurrentReq.parseLine((char *) tmpline.c_str(), rc);
+        if(result < 0) {
+          TRACE(DEBUG, " Parsing of header line failed with " << result)
+          SendSimpleResp(400,NULL,NULL,"Malformed header line. Hint: ensure the line finishes with \"\\r\\n\"", 0, false);
+          return -1;
+        }
+      }
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100010L
         // We permit TLS client auth to be deferred until after the request path is sent.


### PR DESCRIPTION
Adding back in the removed CurrentReq.parseLine so that now more than just the first line of a header is parsed